### PR TITLE
Fix for Pysal#930

### DIFF
--- a/splot/mapping.py
+++ b/splot/mapping.py
@@ -827,7 +827,7 @@ def plot_geocol_bk(gc, color=None, facecolor='#4D4D4D', edgecolor='#B3B3B3',
             tips = []
             ds = dict(x=patch_xs, y=patch_ys)
             for k,v in col.items():
-                ds[k] = v
+                ds[k] = pd.Series(v, index=gc.index).reindex(ids)
                 tips.append((k, "@"+k))
             cds = bk.ColumnDataSource(data=ds)
             h = p.select_one(HoverTool)

--- a/splot/mapping.py
+++ b/splot/mapping.py
@@ -704,7 +704,7 @@ def plot_geocol_mpl(gc, color=None, facecolor='0.3', edgecolor='0.7',
     ids = []
     ## Polygons
     if geom == ps.cg.shapes.Polygon:
-        for id, shape in gc.iteritems():
+        for id, shape in gc.items():
             for ring in shape.parts:
                 xy = np.array(ring)
                 patches.append(xy)
@@ -712,7 +712,7 @@ def plot_geocol_mpl(gc, color=None, facecolor='0.3', edgecolor='0.7',
         mpl_col = PolyCollection(patches)
     ## Lines
     elif geom == ps.cg.shapes.Chain:
-        for id, shape in gc.iteritems():
+        for id, shape in gc.items():
             for xy in shape.parts:
                 patches.append(xy)
                 ids.append(id)
@@ -817,7 +817,7 @@ def plot_geocol_bk(gc, color=None, facecolor='#4D4D4D', edgecolor='#B3B3B3',
     ## Polygons + Lines
     if (geom == ps.cg.shapes.Polygon) or \
             (geom == ps.cg.shapes.Chain):
-        for idx, shape in gc.iteritems():
+        for idx, shape in gc.items():
             for ring in shape.parts:
                 xs, ys = zip(*ring)
                 patch_xs.append(xs)
@@ -826,7 +826,7 @@ def plot_geocol_bk(gc, color=None, facecolor='#4D4D4D', edgecolor='#B3B3B3',
         if hover and col:
             tips = []
             ds = dict(x=patch_xs, y=patch_ys)
-            for k,v in col.iteritems():
+            for k,v in col.items():
                 ds[k] = v
                 tips.append((k, "@"+k))
             cds = bk.ColumnDataSource(data=ds)


### PR DESCRIPTION
This PR proposes a fix for the behaviour reported in [`pysal#930`](https://github.com/pysal/pysal/issues/930). Additionally, it replaces `iteritems` for `items` when looping over `OrderedDict` objects, which makes it automatically Python 2 and 3 compatible (albeit less efficient in Python 2). 
