### PR TITLE
fix setup.py so files are installed with "pip install ."

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include splot/tests/*.py

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,8 @@
 from setuptools import setup
 
-try:
-    from distutils.command.build_py import build_py_2to3 as build_py
-except ImportError:
-    from distutils.command.build_py import build_py
 
 setup(name='splot', #name of package
-      version='1.0.0dev',
+      version='1.0.0.dev0',
       description= 'plotting for PySAL',
       url= 'https://github.com/pysal/splot',
       maintainer= 'Serge Rey',
@@ -27,8 +23,8 @@ setup(name='splot', #name of package
         'Programming Language :: Python :: 3.6'
         ],
       license='3-Clause BSD',
-      packages=[],
+      packages=['splot'],
+      include_package_data=True,
       install_requires=['numpy', 'scipy', 'libpysal', 'mapclassify', 'palettable',
                         'esda', 'pysal',],
-      zip_safe=False,
-      cmdclass = {'build.py':build_py})
+      zip_safe=False)


### PR DESCRIPTION
- changed the version number to remove a warning
- removed 2to3 build command that is no longer needed
- added "splot" to package list so files in the package are included when installing with pip.

The problem here (https://github.com/pysal/esda/pull/19) was that only dummy files got installed:
```
(master) $ python setup.py sdist
/Users/steffie/anaconda3/envs/gsoc/lib/python3.6/site-packages/setuptools/dist.py:388: UserWarning: Normalizing '1.0.0dev' to '1.0.0.dev0'
  normalized_version,
running sdist
running egg_info
creating splot.egg-info
writing splot.egg-info/PKG-INFO
writing dependency_links to splot.egg-info/dependency_links.txt
writing requirements to splot.egg-info/requires.txt
writing top-level names to splot.egg-info/top_level.txt
writing manifest file 'splot.egg-info/SOURCES.txt'
reading manifest file 'splot.egg-info/SOURCES.txt'
writing manifest file 'splot.egg-info/SOURCES.txt'
running check
creating splot-1.0.0.dev0
creating splot-1.0.0.dev0/splot.egg-info
copying files to splot-1.0.0.dev0...
copying README.rst -> splot-1.0.0.dev0
copying setup.py -> splot-1.0.0.dev0
copying splot.egg-info/PKG-INFO -> splot-1.0.0.dev0/splot.egg-info
copying splot.egg-info/SOURCES.txt -> splot-1.0.0.dev0/splot.egg-info
copying splot.egg-info/dependency_links.txt -> splot-1.0.0.dev0/splot.egg-info
copying splot.egg-info/not-zip-safe -> splot-1.0.0.dev0/splot.egg-info
copying splot.egg-info/requires.txt -> splot-1.0.0.dev0/splot.egg-info
copying splot.egg-info/top_level.txt -> splot-1.0.0.dev0/splot.egg-info
Writing splot-1.0.0.dev0/setup.cfg
creating dist
Creating tar archive
removing 'splot-1.0.0.dev0' (and everything under it)
```

Now it installs all the files:
```
(master) $ git checkout fix-setuppy
Switched to branch 'fix-setuppy'

(fix-setuppy) $ python setup.py sdist
running sdist
running egg_info
writing splot.egg-info/PKG-INFO
writing dependency_links to splot.egg-info/dependency_links.txt
writing requirements to splot.egg-info/requires.txt
writing top-level names to splot.egg-info/top_level.txt
reading manifest file 'splot.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'splot.egg-info/SOURCES.txt'
running check
creating splot-1.0.0.dev0
creating splot-1.0.0.dev0/splot
creating splot-1.0.0.dev0/splot.egg-info
creating splot-1.0.0.dev0/splot/tests
copying files to splot-1.0.0.dev0...
copying MANIFEST.in -> splot-1.0.0.dev0
copying README.rst -> splot-1.0.0.dev0
copying setup.py -> splot-1.0.0.dev0
copying splot/__init__.py -> splot-1.0.0.dev0/splot
copying splot/_viz_bokeh.py -> splot-1.0.0.dev0/splot
copying splot/_viz_esda_mpl.py -> splot-1.0.0.dev0/splot
copying splot/_viz_giddy_mpl.py -> splot-1.0.0.dev0/splot
copying splot/_viz_utils.py -> splot-1.0.0.dev0/splot
copying splot/bk.py -> splot-1.0.0.dev0/splot
copying splot/color.py -> splot-1.0.0.dev0/splot
copying splot/esda.py -> splot-1.0.0.dev0/splot
copying splot/folium_mapping.py -> splot-1.0.0.dev0/splot
copying splot/giddy.py -> splot-1.0.0.dev0/splot
copying splot/mapping.py -> splot-1.0.0.dev0/splot
copying splot.egg-info/PKG-INFO -> splot-1.0.0.dev0/splot.egg-info
copying splot.egg-info/SOURCES.txt -> splot-1.0.0.dev0/splot.egg-info
copying splot.egg-info/dependency_links.txt -> splot-1.0.0.dev0/splot.egg-info
copying splot.egg-info/not-zip-safe -> splot-1.0.0.dev0/splot.egg-info
copying splot.egg-info/requires.txt -> splot-1.0.0.dev0/splot.egg-info
copying splot.egg-info/top_level.txt -> splot-1.0.0.dev0/splot.egg-info
copying splot/tests/test_viz_bokeh.py -> splot-1.0.0.dev0/splot/tests
copying splot/tests/test_viz_esda_mpl.py -> splot-1.0.0.dev0/splot/tests
copying splot/tests/test_viz_giddy_mpl.py -> splot-1.0.0.dev0/splot/tests
Writing splot-1.0.0.dev0/setup.cfg
Creating tar archive
removing 'splot-1.0.0.dev0' (and everything under it)
```