### PR TITLE
add `seaborn` and `matplotlib` to `install_requirements` in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(name='splot', #name of package
       license='3-Clause BSD',
       packages=['splot'],
       include_package_data=True,
-      install_requires=['numpy', 'scipy', 'libpysal', 'mapclassify', 'palettable',
-                        'esda', 'pysal',],
+      install_requires=['numpy', 'libpysal', 'mapclassify', 'palettable',
+                        'esda', 'pysal', 'matplotlib', 'seaborn',],
       zip_safe=False)


### PR DESCRIPTION
added `matplotlib` and `seaborn` to install requirements

to fix this issue: https://github.com/pysal/esda/pull/19
and this one: https://github.com/pysal/giddy/pull/47