### PR TITLE
add `moran_facette` functionality and merge `esda.moran` plots to `moran_scatterplot`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ install:
   - pip install https://github.com/pysal/libpysal/archive/master.zip
   # Pysal dependencies removed, therefore need spreg master import
   - pip install https://github.com/pysal/spreg/archive/master.zip
-  # `libpysal` api change requires esda and giddy import from masterbranch
-  - pip install https://github.com/pysal/esda/archive/master.zip
+  # due to the refactoring of libpysals api we need master installs from giddy, esda and mapclassify
   - pip install https://github.com/pysal/giddy/archive/master.zip
-  - pip install palettable mapclassify
+  - pip install https://github.com/pysal/esda/archive/master.zip
+  - pi pinstall https://github.com/pysal/mapclassify/archive/master.zip
   - pip install nose coverage coveralls
   # Now install splot (don't use 'pip install .', we'll run out of space)
   - python setup.py sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   # due to the refactoring of libpysals api we need master installs from giddy, esda and mapclassify
   - pip install https://github.com/pysal/giddy/archive/master.zip
   - pip install https://github.com/pysal/esda/archive/master.zip
-  - pi pinstall https://github.com/pysal/mapclassify/archive/master.zip
+  - pip install https://github.com/pysal/mapclassify/archive/master.zip
   - pip install nose coverage coveralls
   # Now install splot (don't use 'pip install .', we'll run out of space)
   - python setup.py sdist


### PR DESCRIPTION
- add `moran_facet()` with documentation, tests and examples
- add `moran_scatterplot()` that can use all `esda.moran` objects as input
  with documentation, tests and examples

This pull requests builds ontop of bug fixes in #25 
and depends on the integration of `varnames` in esda https://github.com/pysal/esda/pull/23 