### PR TITLE
fix current documentation for sprint

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -104,7 +104,7 @@ html_theme = 'sphinx_rtd_theme'  # 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/splot/_viz_esda_mpl.py
+++ b/splot/_viz_esda_mpl.py
@@ -1218,7 +1218,7 @@ def moran_facet(moran_matrix, figsize=(16,12),
     
     >>> f = gpd.read_file(lp.examples.get_path("sids2.dbf"))
     >>> varnames = ['SIDR74',  'SIDR79',  'NWR74',  'NWR79']
-    >>> vars = [np.array(f.by_col[var]) for var in varnames]
+    >>> vars = [np.array(f[var]) for var in varnames]
     >>> w = lp.io.open(lp.examples.get_path("sids2.gal")).read()
     >>> moran_matrix = Moran_BV_matrix(vars,  w,  varnames = varnames)
     


### PR DESCRIPTION
`moran_facet` plot was not showing in current documentation example

* changed outdated `f.by_col[vars]` to `f[vars]` in example
* commented out `static_` in config file to silence warning during doc build