### PR TITLE
update archaic Miniconda build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ branches:
 only:
   - master
 python:
-  - "3.5"
-  - "3.6"
+  - 3.5
+  - 3.6
 
 before_install:
-  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b -p ./miniconda
   - export PATH=`pwd`/miniconda/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you are new to splot and PySAL you will best get started with our documentati
 
 ### splot requires:
 
-splot is compatible with `Pytho`n 3.5 or later and depends on `geopandas` 0.4.0 or later and `matplotlib` 2.2.2 or later.
+splot is compatible with `Python` 3.5 or later and depends on `geopandas` 0.4.0 or later and `matplotlib` 2.2.2 or later.
 
 splot aslo uses
 * `numpy`


### PR DESCRIPTION
Explicitly specify `Miniconda3` in .`travis.yml`.

pysal/giddy#82
pysal/giddy#83 