### PR TITLE
migrating to readthedocs II

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,3 +6,5 @@ coveralls
 jupyter
 nbconvert
 sphinx_bootstrap_theme
+sphinxcontrib-bibtex
+numpydoc


### PR DESCRIPTION
add `sphinxcontrib-bibtex` and `numpydoc` to `requirements_dev.txt`