### PR TITLE
Add tests for warnings and ValueErrors

### DIFF
--- a/splot/_viz_esda_mpl.py
+++ b/splot/_viz_esda_mpl.py
@@ -1123,7 +1123,7 @@ def _moran_loc_bv_scatterplot(moran_loc_bv, p=None,
         if not isinstance(moran_loc_bv, Moran_Local_BV):
             raise ValueError("`moran_loc_bv` is not a\n" +
                              "esda.moran.Moran_Local_BV instance")
-        if 'color' in scatter_kwds or 'cmap' in scatter_kwds:
+        if 'color' in scatter_kwds or 'c' in scatter_kwds or 'cmap' in scatter_kwds:
             warnings.warn("To change the color use cmap with a colormap of 5,\n" +
                           "c defines the LISA category, color will interfere with c")
 

--- a/splot/_viz_utils.py
+++ b/splot/_viz_utils.py
@@ -245,7 +245,7 @@ def shift_colormap(cmap, start=0, midpoint=0.5, stop=1.0, name='shiftedcmap'):
 
     Parameters
     ----------
-    cmap : matplotlib colormap
+    cmap : str or matplotlib.cm instance
         colormap to be altered
     start : float, optional
         Offset from lowest point in the colormap's range.
@@ -309,7 +309,7 @@ def truncate_colormap(cmap, minval=0.0, maxval=1.0, n=100):
 
     Parameters
     ----------
-    cmap : Mmatplotlib colormap
+    cmap : str or matplotlib.cm instance
         Colormap to be altered
     minval : float, optional
         Minimum value of the original colormap to include
@@ -324,6 +324,9 @@ def truncate_colormap(cmap, minval=0.0, maxval=1.0, n=100):
     -------
     new_cmap : A new colormap that has been shifted. 
     '''
+    if isinstance(cmap, str):
+        cmap = cm.get_cmap(cmap) 
+
     new_cmap = mpl.colors.LinearSegmentedColormap.from_list(
         'trunc({n},{a:.2f},{b:.2f})'.format(n=cmap.name, a=minval, b=maxval),
         cmap(np.linspace(minval, maxval, n)))

--- a/splot/tests/test_viz_esda_mpl.py
+++ b/splot/tests/test_viz_esda_mpl.py
@@ -31,7 +31,7 @@ def test_moran_scatterplot():
     w = Queen.from_dataframe(gdf)
     w.transform = 'r'
     # Calculate `esda.moran` Objects
-    moran = Moran(y,w)
+    moran = Moran(y, w)
     moran_bv = Moran_BV(y, x, w)
     moran_loc = Moran_Local(y, w)
     moran_loc_bv = Moran_Local_BV(y, x, w)
@@ -102,6 +102,7 @@ def test_plot_moran():
                         fitline_kwds=dict(color='#4393c3'))
     plt.close(fig)
 
+
 def test_moran_bv_scatterplot():
     link_to_data = examples.get_path('Guerry.shp')
     gdf = gpd.read_file(link_to_data)
@@ -137,6 +138,7 @@ def test_plot_moran_bv_simulation():
     fig, _ = plot_moran_bv_simulation(moran_bv,
                                       fitline_kwds=dict(color='#4393c3'))
     plt.close(fig)
+
 
 def test_plot_moran_bv():
     # Load data and calculate weights
@@ -176,20 +178,20 @@ def test_moran_loc_scatterplot():
     fig, _ = _moran_loc_scatterplot(moran_loc, p=0.05,
                                     fitline_kwds=dict(color='#4393c3'))
     plt.close(fig)
-    
+
     # try with p value and zstandard=False
     fig, _ = _moran_loc_scatterplot(moran_loc, p=0.05, zstandard=False,
                                     fitline_kwds=dict(color='#4393c3'))
     plt.close(fig)
-    
+
     # try without p value and zstandard=False
     fig, _ = _moran_loc_scatterplot(moran_loc, zstandard=False,
                                     fitline_kwds=dict(color='#4393c3'))
     plt.close(fig)
-    
+
     assert_raises(ValueError, _moran_loc_scatterplot, moran_bv, p=0.5)
     assert_warns(UserWarning, _moran_loc_scatterplot, moran_loc, p=0.5,
-                  scatter_kwds=dict(c='#4393c3'))
+                 scatter_kwds=dict(c='#4393c3'))
 
 
 def test_lisa_cluster():
@@ -243,10 +245,10 @@ def test_moran_loc_bv_scatterplot():
     # try with p value and different figure size
     fig, _ = _moran_loc_bv_scatterplot(moran_loc_bv, p=0.05)
     plt.close(fig)
-    
+
     assert_raises(ValueError, _moran_loc_bv_scatterplot, moran_loc, p=0.5)
     assert_warns(UserWarning, _moran_loc_bv_scatterplot, moran_loc_bv, p=0.5,
-                  scatter_kwds=dict(c='r'))
+                 scatter_kwds=dict(c='r'))
 
 
 def test_moran_facet():
@@ -255,11 +257,11 @@ def test_moran_facet():
     vars = [np.array(f.by_col[var]) for var in varnames]
     w = lp.io.open(examples.get_path("sids2.gal")).read()
     # calculate moran matrix
-    moran_matrix = Moran_BV_matrix(vars,  w,  varnames = varnames)
+    moran_matrix = Moran_BV_matrix(vars, w, varnames=varnames)
     # plot
     fig, axarr = moran_facet(moran_matrix)
     plt.close(fig)
     # customize
     fig, axarr = moran_facet(moran_matrix, scatter_glob_kwds=dict(color='r'),
-                               fitline_bv_kwds=dict(color='y'))
+                             fitline_bv_kwds=dict(color='y'))
     plt.close(fig)

--- a/splot/tests/test_viz_esda_mpl.py
+++ b/splot/tests/test_viz_esda_mpl.py
@@ -4,7 +4,7 @@ import libpysal as lp
 from libpysal import examples
 import geopandas as gpd
 import numpy as np
-from nose.tools import assert_raises
+from nose.tools import assert_raises, assert_warns
 
 from esda.moran import (Moran_Local, Moran, Moran_BV,
                         Moran_Local_BV, Moran_BV_matrix)
@@ -168,8 +168,8 @@ def test_moran_loc_scatterplot():
     moran_loc = Moran_Local(y, w)
     moran_bv = Moran_BV(x, y, w)
 
-    # try with p value so points are colored
-    fig, _ = _moran_loc_scatterplot(moran_loc, p=0.05)
+    # try without p value
+    fig, _ = _moran_loc_scatterplot(moran_loc)
     plt.close(fig)
 
     # try with p value and different figure size
@@ -177,7 +177,19 @@ def test_moran_loc_scatterplot():
                                     fitline_kwds=dict(color='#4393c3'))
     plt.close(fig)
     
+    # try with p value and zstandard=False
+    fig, _ = _moran_loc_scatterplot(moran_loc, p=0.05, zstandard=False,
+                                    fitline_kwds=dict(color='#4393c3'))
+    plt.close(fig)
+    
+    # try without p value and zstandard=False
+    fig, _ = _moran_loc_scatterplot(moran_loc, zstandard=False,
+                                    fitline_kwds=dict(color='#4393c3'))
+    plt.close(fig)
+    
     assert_raises(ValueError, _moran_loc_scatterplot, moran_bv, p=0.5)
+    assert_warns(UserWarning, _moran_loc_scatterplot, moran_loc, p=0.5,
+                  scatter_kwds=dict(c='#4393c3'))
 
 
 def test_lisa_cluster():
@@ -221,7 +233,8 @@ def test_moran_loc_bv_scatterplot():
     y = gdf['Donatns'].values
     w = Queen.from_dataframe(gdf)
     w.transform = 'r'
-    # Calculate Bivariate Moran
+    # Calculate Univariate and Bivariate Moran
+    moran_loc = Moran_Local(y, w)
     moran_loc_bv = Moran_Local_BV(x, y, w)
     # try with p value so points are colored
     fig, _ = _moran_loc_bv_scatterplot(moran_loc_bv)
@@ -230,6 +243,10 @@ def test_moran_loc_bv_scatterplot():
     # try with p value and different figure size
     fig, _ = _moran_loc_bv_scatterplot(moran_loc_bv, p=0.05)
     plt.close(fig)
+    
+    assert_raises(ValueError, _moran_loc_bv_scatterplot, moran_loc, p=0.5)
+    assert_warns(UserWarning, _moran_loc_bv_scatterplot, moran_loc_bv, p=0.5,
+                  scatter_kwds=dict(c='r'))
 
 
 def test_moran_facet():

--- a/splot/tests/test_viz_esda_mpl.py
+++ b/splot/tests/test_viz_esda_mpl.py
@@ -4,6 +4,7 @@ import libpysal as lp
 from libpysal import examples
 import geopandas as gpd
 import numpy as np
+from nose.tools import assert_raises
 
 from esda.moran import (Moran_Local, Moran, Moran_BV,
                         Moran_Local_BV, Moran_BV_matrix)
@@ -159,11 +160,13 @@ def test_moran_loc_scatterplot():
     link = examples.get_path('columbus.shp')
     df = gpd.read_file(link)
 
+    x = df['INC'].values
     y = df['HOVAL'].values
     w = Queen.from_dataframe(df)
     w.transform = 'r'
 
     moran_loc = Moran_Local(y, w)
+    moran_bv = Moran_BV(x, y, w)
 
     # try with p value so points are colored
     fig, _ = _moran_loc_scatterplot(moran_loc, p=0.05)
@@ -173,6 +176,8 @@ def test_moran_loc_scatterplot():
     fig, _ = _moran_loc_scatterplot(moran_loc, p=0.05,
                                     fitline_kwds=dict(color='#4393c3'))
     plt.close(fig)
+    
+    assert_raises(ValueError, _moran_loc_scatterplot, moran_bv, p=0.5)
 
 
 def test_lisa_cluster():

--- a/splot/tests/test_viz_giddy_mpl.py
+++ b/splot/tests/test_viz_giddy_mpl.py
@@ -4,6 +4,7 @@ from libpysal.weights.contiguity import Queen
 from libpysal import examples
 import numpy as np
 import matplotlib.pyplot as plt
+from nose.tools import assert_raises
 
 from giddy.directional import Rose
 from splot.giddy import (dynamic_lisa_heatmap,
@@ -53,6 +54,9 @@ def test_dynamic_lisa_rose():
     
     fig3, _ = dynamic_lisa_rose(rose, c='r')
     plt.close(fig3)
+    
+    assert_raises(ValueError, dynamic_lisa_rose,
+                  rose, attribute=y1, color='blue')
 
 
 def test_dynamic_lisa_vectors():
@@ -65,6 +69,10 @@ def test_dynamic_lisa_vectors():
     
     fig3, _ = dynamic_lisa_vectors(rose, c='r')
     plt.close(fig3)
+    
+    fig4, axs = plt.subplots(1,3)
+    dynamic_lisa_vectors(rose, ax=axs[0], color='r')
+    plt.close(fig4)
 
 
 def test_dynamic_lisa_composite():

--- a/splot/tests/test_viz_libpysal_mpl.py
+++ b/splot/tests/test_viz_libpysal_mpl.py
@@ -23,6 +23,10 @@ def test_plot_spatial_weights():
     #customize
     fig3, _ = plot_spatial_weights(wnp, gdf, nonplanar_edge_kws=dict(color='#4393c3'))
     plt.close(fig3)
+    # plot in existing figure
+    fig4, axs = plt.subplots(1,3)
+    plot_spatial_weights(wnp, gdf, ax=axs[0])
+    plt.close(fig4)
 
     # uses a column as the index for spatial weights object
     weights_index = Queen.from_dataframe(gdf, idVariable="CD_GEOCMU")

--- a/splot/tests/test_viz_utils.py
+++ b/splot/tests/test_viz_utils.py
@@ -1,14 +1,16 @@
 from splot._viz_utils import shift_colormap, truncate_colormap
 import matplotlib as mpl
 
+
 def test_shift_colormap():
     map_test = shift_colormap('RdBu', start=0.1,
-                               midpoint=0.2,
-                               stop=0.9,
-                               name='shiftedcmap')
+                              midpoint=0.2,
+                              stop=0.9,
+                              name='shiftedcmap')
     assert isinstance(map_test, mpl.colors.LinearSegmentedColormap)
+
 
 def test_truncat_colormap():
     map_test_truncate = truncate_colormap('RdBu', minval=0.1,
-                                         maxval=0.9, n=99)
+                                          maxval=0.9, n=99)
     assert isinstance(map_test_truncate, mpl.colors.LinearSegmentedColormap)

--- a/splot/tests/test_viz_utils.py
+++ b/splot/tests/test_viz_utils.py
@@ -1,0 +1,14 @@
+from splot._viz_utils import shift_colormap, truncate_colormap
+import matplotlib as mpl
+
+def test_shift_colormap():
+    map_test = shift_colormap('RdBu', start=0.1,
+                               midpoint=0.2,
+                               stop=0.9,
+                               name='shiftedcmap')
+    assert isinstance(map_test, mpl.colors.LinearSegmentedColormap)
+
+def test_truncat_colormap():
+    map_test_truncate = truncate_colormap('RdBu', minval=0.1,
+                                         maxval=0.9, n=99)
+    assert isinstance(map_test_truncate, mpl.colors.LinearSegmentedColormap)


### PR DESCRIPTION
* add `test_viz_utils.py` with `test_truncate_colormap()` and `test_shift_colormap()`
* add tests for ValueError and Warning in `test_viz_giddy_mpl.py` and `test_viz-esda_mpl.py`
* pep8 fixes
* add warning to `_moran_loc_bv-scatterplot()`
* add option to input a str in `truncate_colormap()`