### PR TITLE
docs building using readthedocs.yml version 2

### DIFF
--- a/doc/_static/pysal-styles.css
+++ b/doc/_static/pysal-styles.css
@@ -71,3 +71,7 @@
 /* Table with a scrollbar */
 .bodycontainer { max-height: 600px; width: 100%; margin: 0; overflow-y: auto; }
 .table-scrollable { margin: 0; padding: 0; }
+
+div.body {
+    max-width: 1080px;
+}

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -16,11 +16,3 @@ python:
           path: .
           extra_requirements:
               - dev
-
-
-#python:
-#    version: 3.5
-#    setup_py_install: true
-#    pip_install: true
-#    extra_requirements:
-#        - dev

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,26 @@
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
 python:
-    version: 3.5
-    setup_py_install: true
-    pip_install: true
-    extra_requirements:
-        - dev
+    version: 3.7
+    install:
+        - requirements: requirements.txt
+        - method: pip
+          path: .
+          extra_requirements:
+              - dev
+
+
+#python:
+#    version: 3.5
+#    setup_py_install: true
+#    pip_install: true
+#    extra_requirements:
+#        - dev


### PR DESCRIPTION
migrate from readthedocs configuration file v1 to v2

docs building is successful on [my fork](https://readthedocs.org/projects/splot-wei/builds/9088586/) 