### PR TITLE
[DOC] include rtree and descartes in `requirements_dev.txt`

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,3 +8,5 @@ nbconvert
 sphinx_bootstrap_theme
 sphinxcontrib-bibtex
 numpydoc
+descartes
+rtree


### PR DESCRIPTION
included tree and Descartes in `requirements_dev.txt ` in order to build visualisations in readthedocs

fixes #66 