### PR TITLE
set up dual travis tests for pysal dependencies (pip and github) 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,13 @@ env:
   - PYSAL_PYPI=true #testing on dependencies libpysal, esda, mapcalssify, giddy and spreg on pypi
   - PYSAL_PYPI=false
 
-
+matrix:
+  allow_failures:
+      - python: 3.6
+        env: PYSAL_PYPI=false
+      - python: 3.7
+        env: PYSAL_PYPI=false
+        
 before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
         env: PYSAL_PYPI=false
       - python: 3.7
         env: PYSAL_PYPI=false
-        
+
 before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
@@ -40,11 +40,11 @@ install:
       echo 'testing pypi libpysal esda mapclassify giddy spreg';
     else
       echo 'testing git libpysal esda mapclassify giddy spreg';
-      git clone https://github.com/pysal/libpysal.git; cd libpysal; pip install .; cd ../;
-      git clone https://github.com/pysal/mapclassify.git; cd mapclassify; pip install .; cd ../;
-      git clone https://github.com/pysal/esda.git; cd esda; pip install .; cd ../;
-      git clone https://github.com/pysal/giddy.git; cd giddy; pip install .; cd ../;
-      git clone https://github.com/pysal/spreg.git; cd spreg; pip install .; cd ../;
+      pip install https://github.com/pysal/libpysal/archive/master.zip;
+      pip install https://github.com/pysal/mapclassify/archive/master.zip;
+      pip install https://github.com/pysal/esda/archive/master.zip;
+      pip install https://github.com/pysal/giddy/archive/master.zip;
+      pip install https://github.com/pysal/spreg/archive/master.zip;
     fi;
   - pip install nose coverage coveralls
   # Now install splot (don't use 'pip install .', we'll run out of space)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,3 +8,4 @@ nbconvert
 sphinx_bootstrap_theme
 sphinxcontrib-bibtex
 numpydoc
+descartes


### PR DESCRIPTION
This PR is to set up dual travis tests for pysal dependencies (on pip and github):
* libpysal
* mapclassify
* esda
* giddy
* spreg

[The tests against github version are failing](https://travis-ci.org/weikang9009/splot) because of [the API change to mapclassify](https://github.com/pysal/splot/issues/65).
