### PR TITLE
[BUG] require geopandas>=0.4.0,<=0.6.0rc1 for vba_choropleth testing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-geopandas>=0.4.0
+geopandas>=0.4.0,<=0.6.0rc1
 matplotlib
 seaborn
 libpysal


### PR DESCRIPTION
add `,<=0.6.0rc1` in `requirements.txt` to allow testing on travis

Note: this is a work-around solution, the bug will be addressed in cooperation with GeoPandas team