### PR TITLE
Fix docstring for plot_spatial_weights

### DIFF
--- a/splot/_viz_libpysal_mpl.py
+++ b/splot/_viz_libpysal_mpl.py
@@ -21,8 +21,8 @@ def plot_spatial_weights(w, gdf, indexed_on=None, ax=None,
     NOTE: Additionally plots `w.non_planar_joins` if
     `libpysal.weights.util.nonplanar_neighbors()` was applied.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     w : libpysal.W object
         Values of libpysal weights object.
     gdf : geopandas dataframe 


### PR DESCRIPTION
I noticed a minor issue with `plot_spatial_weights` docstring as it uses `Arguments` instead of `Parameters`, so it is not visible in [docs](https://splot.readthedocs.io/en/latest/generated/splot.libpysal.plot_spatial_weights.html#splot.libpysal.plot_spatial_weights).

Just a side note, this second point in your PR template is no longer valid, right?  `pysal/dev` is way behind master.

> 2. [ ] This pull request is directed to the `pysal/dev` branch.

cc https://github.com/openjournals/joss-reviews/issues/1882