### PR TITLE
BUG: Fix breakage due to mapclassify deprecation

### DIFF
--- a/splot/_viz_utils.py
+++ b/splot/_viz_utils.py
@@ -73,19 +73,19 @@ def mask_local_auto(moran_loc, p=0.5):
 
 
 _classifiers = {
-    'box_plot': classify.Box_Plot,
-    'equal_interval': classify.Equal_Interval,
-    'fisher_jenks': classify.Fisher_Jenks,
-    'headtail_breaks': classify.HeadTail_Breaks,
-    'jenks_caspall': classify.Jenks_Caspall,
-    'jenks_caspall_forced': classify.Jenks_Caspall_Forced,
-    'max_p_classifier': classify.Max_P_Classifier,
-    'maximum_breaks': classify.Maximum_Breaks,
-    'natural_breaks': classify.Natural_Breaks,
+    'box_plot': classify.BoxPlot,
+    'equal_interval': classify.EqualInterval,
+    'fisher_jenks': classify.FisherJenks,
+    'headtail_breaks': classify.HeadTailBreaks,
+    'jenks_caspall': classify.JenksCaspall,
+    'jenks_caspall_forced': classify.JenksCaspallForced,
+    'max_p_classifier': classify.MaxP,
+    'maximum_breaks': classify.MaximumBreaks,
+    'natural_breaks': classify.NaturalBreaks,
     'quantiles': classify.Quantiles,
     'percentiles': classify.Percentiles,
-    'std_mean': classify.Std_Mean,
-    'user_defined': classify.User_Defined,
+    'std_mean': classify.StdMean,
+    'user_defined': classify.UserDefined,
     }
 
 

--- a/splot/_viz_value_by_alpha_mpl.py
+++ b/splot/_viz_value_by_alpha_mpl.py
@@ -416,7 +416,7 @@ def mapclassify_bin(y, classifier, k=5, pct=[1,10,50,90,99,100],
         Percentiles used for classification with `percentiles`.
         Default=[1,10,50,90,99,100]
     hinge : float, optional
-        Multiplier for IQR when `Box_Plot` classifier used.
+        Multiplier for IQR when `BoxPlot` classifier used.
         Default=1.5.
     multiples : array, optional
         The multiples of the standard deviation to add/subtract from


### PR DESCRIPTION
[mapclassify 2.2.0](https://github.com/pysal/mapclassify/releases/tag/v2.2.0) removed deprecated class names.