### PR TITLE
[DOC] add example links to README.md & figure captions in joss article

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 `splot` connects spatial analysis done in [`PySAL`](https://github.com/pysal) to different popular visualization toolkits like [`matplotlib`](https://matplotlib.org).
 The `splot` package allows you to create both static plots ready for publication and interactive visualizations for quick iteration and spatial data exploration. The primary goal of `splot` is to enable you to visualize popular PySAL objects and gives you different views on your spatial analysis workflow.
 
-If you are new to splot and PySAL you will best get started with our [documentation](https://splot.readthedocs.io/en/latest/)!
+If you are new to splot and PySAL you will best get started with our [documentation](https://splot.readthedocs.io/en/latest/) and the short introduction [video](https://youtu.be/kriQOJMycIQ?t=2403) of the package at the Scipy 2018 conference!
 
 ## Installing splot
 
@@ -61,8 +61,18 @@ Otherwise you can install splot from PyPI with pip:
 
 ## Usage
 
-splot supports many different 
-https://github.com/pysal/splot/blob/master/notebooks/mapping_vba.ipynb
+Usage examples for different spatial statistical workflows are provided as [notebooks](https://github.com/pysal/splot/tree/master/notebooks):
+* [for creating value-by-alpha maps](https://github.com/pysal/splot/blob/master/notebooks/mapping_vba.ipynb)
+* [for assessing the relationship between neighbouring polygones](https://github.com/pysal/splot/blob/master/notebooks/libpysal_non_planar_joins_viz.ipynb)
+* [for the visualization of space-time autocorrelation](https://github.com/pysal/splot/blob/master/notebooks/giddy_space_time.ipynb), also documented in [giddy](https://github.com/pysal/giddy/blob/master/notebooks/directional.ipynb)
+* for visualizing spatial autocorrelation of [univariate](https://github.com/pysal/splot/blob/master/notebooks/esda_morans_viz.ipynb) or [multivariate](https://github.com/pysal/splot/blob/master/notebooks/esda_moran_matrix_viz.ipynb) variable analysis
+
+You can also check our [documentation](https://splot.readthedocs.io/en/latest/) for examples on how to use each function.
+
+A detailed report about the development, structure and usage of splot can be found [here](https://gist.github.com/slumnitz/a86ef4a5b48b1b5fac41e91cfd05fff2). 
+
+
+
 
 ## Contributing to splot
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@
 ## What is splot?
 
 `splot` connects spatial analysis done in [`PySAL`](https://github.com/pysal) to different popular visualization toolkits like [`matplotlib`](https://matplotlib.org).
-The `splot` package allows you to create both static plots ready for publication and interactive visualizations for quick iteration and spatial data exploration. The primary goal of `splot` is to enable you to visualize popular PySAL objects and gives you different views on your spatial analysis workflow.
+The `splot` package allows you to create both static plots ready for publication and interactive visualizations for quick iteration and spatial data exploration. The primary goal of `splot` is to enable you to visualize popular `PySAL` objects and gives you different views on your spatial analysis workflow.
 
-If you are new to splot and PySAL you will best get started with our [documentation](https://splot.readthedocs.io/en/latest/) and the short introduction [video](https://youtu.be/kriQOJMycIQ?t=2403) of the package at the Scipy 2018 conference!
+If you are new to `splot` and `PySAL` you will best get started with our [documentation](https://splot.readthedocs.io/en/latest/) and the short introduction [video](https://youtu.be/kriQOJMycIQ?t=2403) of the package at the Scipy 2018 conference!
 
 ## Installing splot
 
 ### Installing dependencies:
 
-splot is compatible with `Python` 3.6 and 3.7 and depends on `geopandas` 0.4.0 or later and `matplotlib` 2.2.2 or later.
+`splot` is compatible with `Python` 3.6 and 3.7 and depends on `geopandas` 0.4.0 or later and `matplotlib` 2.2.2 or later.
 
 splot also uses
 * `numpy`
@@ -29,10 +29,10 @@ splot also uses
 * `mapclassify`
 * `Ipywidgets`
 
-Depending on your spatial analysis workflow and the PySAL objects you would like to visualize, splot relies on:
+Depending on your spatial analysis workflow and the `PySAL` objects you would like to visualize, `splot` relies on:
 * PySAL 2.0
 
-or separate packages found in the PySAL stack:
+or separate packages found in the `PySAL` stack:
 * esda
 * libpysal
 * spreg
@@ -40,7 +40,7 @@ or separate packages found in the PySAL stack:
 
 ### Installing splot:
 
-There are two ways of accessing splot. First, splot is installed with the [PySAL 2.0](https://pysal.readthedocs.io/en/latest/installation.html) metapackage through:
+There are two ways of accessing `splot`. First, `splot` is installed with the [PySAL 2.0](https://pysal.readthedocs.io/en/latest/installation.html) metapackage through:
 
     $ pip install -U pysal
     
@@ -49,12 +49,12 @@ There are two ways of accessing splot. First, splot is installed with the [PySAL
     $ conda install -c conda-forge pysal
 
 
-Second, splot can be installed as a separate package. If you are using Anaconda, install splot via the conda utility:
+Second, `splot` can be installed as a separate package. If you are using Anaconda, install `splot` via the `conda` utility:
 
     $ conda install -c conda-forge splot
 
 
-Otherwise you can install splot from PyPI with pip:
+Otherwise you can install `splot` from `PyPI` with pip:
 
     $ pip install splot
 
@@ -63,13 +63,11 @@ Otherwise you can install splot from PyPI with pip:
 
 Usage examples for different spatial statistical workflows are provided as [notebooks](https://github.com/pysal/splot/tree/master/notebooks):
 * [for creating value-by-alpha maps](https://github.com/pysal/splot/blob/master/notebooks/mapping_vba.ipynb)
-* [for assessing the relationship between neighbouring polygones](https://github.com/pysal/splot/blob/master/notebooks/libpysal_non_planar_joins_viz.ipynb)
+* [for assessing the relationship between neighboring polygons](https://github.com/pysal/splot/blob/master/notebooks/libpysal_non_planar_joins_viz.ipynb)
 * [for the visualization of space-time autocorrelation](https://github.com/pysal/splot/blob/master/notebooks/giddy_space_time.ipynb), also documented in [giddy](https://github.com/pysal/giddy/blob/master/notebooks/directional.ipynb)
 * for visualizing spatial autocorrelation of [univariate](https://github.com/pysal/splot/blob/master/notebooks/esda_morans_viz.ipynb) or [multivariate](https://github.com/pysal/splot/blob/master/notebooks/esda_moran_matrix_viz.ipynb) variable analysis
 
-You can also check our [documentation](https://splot.readthedocs.io/en/latest/) for examples on how to use each function.
-
-A detailed report about the development, structure and usage of splot can be found [here](https://gist.github.com/slumnitz/a86ef4a5b48b1b5fac41e91cfd05fff2). 
+You can also check our [documentation](https://splot.readthedocs.io/en/latest/) for examples on how to use each function. A detailed report about the development, structure and usage of `splot` can be found [here](https://gist.github.com/slumnitz/a86ef4a5b48b1b5fac41e91cfd05fff2). More tutorials for the whole `PySAL` ecosystem can be found in our [notebooks book](http://pysal.org/notebooks/intro.html) project.
 
 
 
@@ -78,20 +76,20 @@ A detailed report about the development, structure and usage of splot can be fou
 
 `splot` is an open source project within the Python Spatial Analysis Library that is supported by a community of Geographers, visualization lovers, map fans, users and data scientists. As a community we work together to create splot as our own spatial visualization toolkit and will gratefully and humbly accept any contributions and ideas you might bring into this project. 
 
-Feel free to check out our dicussion spaces, add ideas and contributions:
+Feel free to check out our discussion spaces, add ideas and contributions:
 * [Idea collection](https://github.com/pysal/splot/issues/10) which PySAL objects to support and how new visualizations could look like
 * [Discussion](https://github.com/pysal/splot/issues/9) about the splot API
 * Ideas how to integrate [other popular visualization toolkits](https://github.com/pysal/splot/issues/22) like `Bokeh` or `Altair`
 
-If you have never contributed before or you are just discovering what PySAL and splot have to offer, reading through """Doc-strings""" and correcting our Documentation can be a great way to start. Check for spelling and grammar mistakes or use [pep8](https://pypi.org/project/pep8/) and [pyflakes](https://pypi.org/project/pyflakes/) to clean our `.py` files. This will allow you to get used to working with [git](https://try.github.io) and generally allows you to familiarize yourself with the `splot` and `PySAL` code base.
+If you have never contributed before or you are just discovering what `PySAL` and `splot` have to offer, reading through """Doc-strings""" and correcting our Documentation can be a great way to start. Check for spelling and grammar mistakes or use [pep8](https://pypi.org/project/pep8/) and [pyflakes](https://pypi.org/project/pyflakes/) to clean our `.py` files. This will allow you to get used to working with [git](https://try.github.io) and generally allows you to familiarize yourself with the `splot` and `PySAL` code base.
 
-If you have already used PySAL and splot and you are missing object-specific views for your analysis feel free to add to our code-base or discuss your ideas. Please make sure you include unit test, documentation and examples or (create an issue so someone else can work together with you). The common `splot` API design discussed [here](https://github.com/pysal/splot/issues/9) can help you to decide how to best integrate your visualization prototype into `splot`.
+If you have already used `PySAL` and `splot` and you are missing object-specific views for your analysis feel free to add to our code-base or discuss your ideas. Please make sure you include unit test, documentation and examples or (create an issue so someone else can work together with you). The common `splot` API design discussed [here](https://github.com/pysal/splot/issues/9) can help you to decide how to best integrate your visualization prototype into `splot`.
 
 Beyond working on documentation and prototyping new visualizations, you can always write a bug report or feature request on [Github issues](https://github.com/pysal/splot/issues). Whether large or small, any contribution makes a big difference and we hope you enjoy being part of our community as much as we do! The only thing we ask is that you abide principles of openness, respect, and consideration of others as described in the [PySAL Code of Conduct](https://github.com/pysal/code_of_conduct/blob/master/README.md).
 
 ## Road-map
 
-We are planning on extending splot's visualization toolkit in future. Functionality we plan to implement includes:
+We are planning on extending `splot`'s visualization toolkit in future. Functionality we plan to implement includes:
 
 * visualisations for [density methods](https://github.com/pysal/splot/issues/32) (mapping density estimations)
 * [cross-hatching fill styles](https://github.com/pysal/splot/issues/35) for maps (to allow choropleth visualizations without class intervals)

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -3,23 +3,70 @@
 Installation
 ============
 
-splot supports python `3.5`_ and `3.6`_ only. Please make sure that you are
-operating in a python 3 environment.
+Installing dependencies
+-----------------------
 
-Installing released version
----------------------------
+`splot` is compatible with Python `3.6`_ and `3.7`_ and
+depends on GeoPandas 0.4.0 or later and matplotlib 2.2.2 or later.
+Please make sure that you are operating in a Python 3 environment.
 
-giddy is available on the TBA. Therefore, you can either
-install directly with `pip` from the command line::
+splot also uses
 
-  pip install splot
+* numpy
+* seaborn
+* mapclassify
+* Ipywidgets
+
+Depending on your spatial analysis workflow and the PySAL objects
+you would like to visualize, splot relies on:
+
+PySAL 2.0
+
+or separate packages found in the PySAL stack:
+
+* esda
+* libpysal
+* spreg
+* giddy
 
 
-or download the source distribution (.tar.gz) and decompress it to your selected
-destination. Open a command shell and navigate to the decompressed folder.
-Type::
+Installing the newest release
+-----------------------------
 
-  pip install .
+There are two ways of accessing splot. First, splot is installed with
+the PySAL 2.0 metapackage through:
+
+```$ pip install -U pysal```
+
+or 
+
+```$ conda install -c conda-forge pysal```
+
+Second, splot can be installed as a separate package. If you are
+using Anaconda, install splot via the conda utility:
+
+```$ conda install -c conda-forge splot```
+
+Otherwise you can install splot from PyPI with pip:
+
+```$ pip install splot```
+
+
+Trouble shooting
+----------------
+Most common installation errors are due to splot's dependency on GeoPandas.
+
+It often helps to first install GeoPandas separately from conda-forge with:
+
+```$ conda install geopandas```
+
+before installing splot (preferably also from conda, alternatively from pip).
+
+For more information on troubleshooting the installation of GeoPandas wiht pip, see the `GeoPandas`_ docuemntation.
+
+It is also possible to install splot with a later Python version (>3.7)
+through the separate installation of GeoPandas or through installation wiht conda-forge.
+
 
 Installing development version
 ------------------------------
@@ -36,7 +83,9 @@ your fork. By making changes
 to your local clone and submitting a pull request to `pysal/splot`_, you can
 contribute to the splot development.
 
-.. _3.5: https://docs.python.org/3.5/
 .. _3.6: https://docs.python.org/3.6/
+.. _3.7: https://docs.python.org/3.7/
+.. _GeoPandas: http://geopandas.org/install.html
 .. _pysal/splot: https://github.com/pysal/splot
 .. _fork: https://help.github.com/articles/fork-a-repo/
+

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -62,10 +62,11 @@ It often helps to first install GeoPandas separately from conda-forge with:
 
 before installing splot (preferably also from conda, alternatively from pip).
 
-For more information on troubleshooting the installation of GeoPandas wiht pip, see the `GeoPandas`_ docuemntation.
+For more information on troubleshooting the installation of GeoPandas with pip, see the `GeoPandas`_ docuemntation.
 
 It is also possible to install splot with a later Python version (>3.7)
 through the separate installation of GeoPandas or through installation wiht conda-forge.
+(Note that splot is currently oonly tested for Python version 3.6 and 3.7)
 
 
 Installing the development version

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -65,8 +65,8 @@ before installing splot (preferably also from conda, alternatively from pip).
 For more information on troubleshooting the installation of GeoPandas with pip, see the `GeoPandas`_ docuemntation.
 
 It is also possible to install splot with a later Python version (>3.7)
-through the separate installation of GeoPandas or through installation wiht conda-forge.
-(Note that splot is currently oonly tested for Python version 3.6 and 3.7)
+through the separate installation of GeoPandas or through installation with conda-forge.
+(Note that splot is currently only tested for Python version 3.6 and 3.7)
 
 
 Installing the development version

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -20,9 +20,9 @@ splot also uses
 Depending on your spatial analysis workflow and the PySAL objects
 you would like to visualize, splot relies on:
 
-PySAL 2.0
+PySAL >=2.0
 
-or separate packages found in the PySAL stack:
+or the installation of separate packages found in the PySAL stack:
 
 * esda
 * libpysal
@@ -47,18 +47,18 @@ using Anaconda, install splot via the conda utility:
 
 ```$ conda install -c conda-forge splot```
 
-Otherwise you can install splot from PyPI with pip:
+Otherwise, you can install splot from PyPI with pip:
 
 ```$ pip install splot```
 
 
-Trouble shooting
-----------------
+Troubleshooting
+---------------
 Most common installation errors are due to splot's dependency on GeoPandas.
 
 It often helps to first install GeoPandas separately from conda-forge with:
 
-```$ conda install geopandas```
+```$ conda install --channel conda-forge geopandas```
 
 before installing splot (preferably also from conda, alternatively from pip).
 
@@ -68,8 +68,8 @@ It is also possible to install splot with a later Python version (>3.7)
 through the separate installation of GeoPandas or through installation wiht conda-forge.
 
 
-Installing development version
-------------------------------
+Installing the development version
+----------------------------------
 
 Potentially, you might want to use the newest features in the development
 version of splot on github - `pysal/splot`_ while have not been incorporated

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -73,7 +73,7 @@ plt.show()
 ```
 
 
-[![Fig. 1: Local Spatial Autocorrelation](figs/local_autocorrelation.png)](https://github.com/pysal/splot/blob/master/notebooks/esda_morans_viz.ipynb)
+[![Fig. 1: Local Spatial Autocorrelation](figs/local_autocorrelation.png)](https://github.com/pysal/splot/blob/master/notebooks/esda_morans_viz.ipynb)*Fig. 1: Local spatial autocorrelation*
 
 The user can now further visually assess whether there is dependency between high crime rates (fig. 2, rgb variable) and high income in this neighborhood (fig. 2, alpha variable). Darker shades of the colormap correspond to higher crime and income values, displayed through a static Value-by-Alpha Choropleth using `splot.mapping.vba_choropleth`.
 
@@ -90,7 +90,7 @@ plt.show()
 ```
 
 
-[![Fig. 2: Value-by-alpha mapping](figs/vba_choropleth.png)](https://github.com/pysal/splot/blob/master/notebooks/mapping_vba.ipynb)
+[![Fig. 2: Value-by-alpha mapping](figs/vba_choropleth.png)](https://github.com/pysal/splot/blob/master/notebooks/mapping_vba.ipynb)*Fig. 2: Value-by-alpha mapping*
 
 Ultimately, the `splot` package is designed to facilitate the creation of both static plots ready for publication, and interactive visualizations for quick iteration and spatial data exploration. Although most of `splot` is currently implemented with a `matplotlib` backend, `splot` is framework independent. In that sense, `splot` offers a "grammar" of views that are important and useful in spatial analyses and geographic data science. The `splot` package is not restricted or limited to the current `matplotlib` implementation and can be advanced by integrating emerging or succeeding interactive visualization toolkits, such as `altair` or `bokeh`.
 


### PR DESCRIPTION
This PR builds on top of #96 and addresses #90 and #92 

* add figure captions in `paper.md` through markdown italics formatting
* add links of notebook examples and other material to `README.md` under `Usage` section
* add script lightning talk as documentation under introduction in `README.md`