### PR TITLE
Release1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changes
 
+# Version 1.1.3 (2020-03-18)
+
+We closed a total of 15 issues (enhancements and bug fixes) through 6 pull requests, since our last release on 2020-01-18.
+
+## Issues Closed
+  - add permanent links to current version of no's to joss paper (#102)
+  - [BUG] set colors as list in _plot_choropleth_fig() (#101)
+  - Remove the links around figures in the JOSS paper (#99)
+  - Release prep for 1.1.2 (#98)
+  - Installation instructions; pip install fails on macOS (#88)
+  - Usage in readme is a fragment (#90)
+  - JOSS: missing figure captions (#92)
+  - [DOC] update installation instruction (#96)
+  - [DOC] add example links to README.md & figure captions in joss article (#97)
+
+## Pull Requests
+  - add permanent links to current version of no's to joss paper (#102)
+  - [BUG] set colors as list in _plot_choropleth_fig() (#101)
+  - Remove the links around figures in the JOSS paper (#99)
+  - Release prep for 1.1.2 (#98)
+  - [DOC] update installation instruction (#96)
+  - [DOC] add example links to README.md & figure captions in joss article (#97)
+
+The following individuals contributed to this release:
+
+  - Stefanie Lumnitz
+  - Levi John Wolf
+  - Leonardo Uieda
+  - Serge Rey
+
 # Version 1.1.2 (2020-01-18)
 
 We closed a total of 33 issues (enhancements and bug fixes) through 13 pull requests, since our last release on 2019-07-13.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 from setuptools import setup
 from os import path
 
+package = "splot"
+
+# Get __version__ from package/__init__.py
+with open(package + "/__init__.py", "r") as f:
+    exec(f.readline())
+
 def _get_requirements_from_files(groups_files):
     groups_reqlist = {}
 
@@ -25,8 +31,8 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
     
-setup(name='splot', #name of package
-      version='1.1.3',
+setup(name=package, #name of package
+      version=__version__,
       description='Visual analytics for spatial analysis with PySAL.',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
     
 setup(name='splot', #name of package
-      version='1.1.2',
+      version='1.1.3',
       description='Visual analytics for spatial analysis with PySAL.',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/splot/__init__.py
+++ b/splot/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 # __version__ has to be defined in the first line
 
 


### PR DESCRIPTION
# Changes

Version 1.1.3 (2020-03-18)

We closed a total of 15 issues (enhancements and bug fixes) through 6 pull requests, since our last release on 2020-01-18.

## Issues Closed
  - add permanent links to current version of no's to joss paper (#102)
  - [BUG] set colors as list in _plot_choropleth_fig() (#101)
  - Remove the links around figures in the JOSS paper (#99)
  - Release prep for 1.1.2 (#98)
  - Installation instructions; pip install fails on macOS (#88)
  - Usage in readme is a fragment (#90)
  - JOSS: missing figure captions (#92)
  - [DOC] update installation instruction (#96)
  - [DOC] add example links to README.md & figure captions in joss article (#97)

## Pull Requests
  - add permanent links to current version of no's to joss paper (#102)
  - [BUG] set colors as list in _plot_choropleth_fig() (#101)
  - Remove the links around figures in the JOSS paper (#99)
  - Release prep for 1.1.2 (#98)
  - [DOC] update installation instruction (#96)
  - [DOC] add example links to README.md & figure captions in joss article (#97)

The following individuals contributed to this release:

  - Stefanie Lumnitz
  - Levi John Wolf
  - Leonardo Uieda
  - Serge Rey