### PR TITLE
[BUG] pin seaborn to v0.10.0 for testing new functionality

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 geopandas>=0.4.0
 matplotlib
-seaborn
+seaborn==0.10.0
 libpysal
 mapclassify
 esda


### PR DESCRIPTION
Temporarily pinning seaborn to v0.10.0 in `requirements.txt` for 
* implementing and testing new functionality and use of `pytest`
* maintenance of CI