### PR TITLE
[MAINT] update links to Guerry dataset in `_test_data()`

### DIFF
--- a/splot/_viz_giddy_mpl.py
+++ b/splot/_viz_giddy_mpl.py
@@ -290,12 +290,19 @@ def dynamic_lisa_rose(rose, attribute=None, ax=None, **kwargs):
 def _add_arrow(line, position=None, direction='right', size=15, color=None):
     """
     add an arrow to a line.
-
-    line:       Line2D object
-    position:   x-position of the arrow. If None, mean of xdata is taken
-    direction:  'left' or 'right'
-    size:       size of the arrow in fontsize points
-    color:      if None, line color is taken.
+    
+    Parameters
+    ----------
+    line:
+        Line2D object
+    position: float
+        x-position of the arrow. If None, mean of xdata is taken
+    direction: str
+        'left' or 'right'
+    size: int
+        size of the arrow in fontsize points
+    color: str
+        if None, line color is taken.
 
     """
     if color is None:
@@ -384,7 +391,7 @@ def dynamic_lisa_vectors(rose, ax=None,
 
     customize plot
 
-    >>> dynamic_lisa_vectors(rose, arrows=False, c='r')
+    >>> dynamic_lisa_vectors(rose, arrows=False, color='r')
     >>> plt.show()
 
     """
@@ -398,9 +405,13 @@ def dynamic_lisa_vectors(rose, ax=None,
 
     xlim = [rose.Y.min(), rose.Y.max()]
     ylim = [rose.wY.min(), rose.wY.max()]
-
-    color = kwargs.pop('color', 'b')
-    can_insert_colorbar = False
+    
+    if 'c' in kwargs.keys():
+        color = kwargs.pop('c', 'b')
+        can_insert_colorbar = False
+    else:
+        color = kwargs.pop('color', 'b')
+        can_insert_colorbar = False
 
     xs = []
     ys = []

--- a/splot/_viz_giddy_mpl.py
+++ b/splot/_viz_giddy_mpl.py
@@ -335,7 +335,6 @@ def dynamic_lisa_vectors(rose, ax=None,
         If True show arrowheads of vectors. Default =True
     **kwargs : keyword arguments, optional
         Keywords used for creating and designing the `matplotlib.pyplot.plot()`
-        Note: 'c' and 'color' cannot be passed when attribute is not None.
 
     Returns
     -------

--- a/splot/tests/test_viz_esda_mpl.py
+++ b/splot/tests/test_viz_esda_mpl.py
@@ -22,10 +22,14 @@ from splot._viz_esda_mpl import (_moran_global_scatterplot,
                                  _moran_bv_scatterplot,
                                  _moran_loc_bv_scatterplot)
 
+def _test_data():
+    guerry = examples.load_example('Guerry')
+    link_to_data = guerry.get_path('guerry.shp')
+    gdf = gpd.read_file(link_to_data)
+    return gdf
 
 def test_moran_scatterplot():
-    link_to_data = examples.get_path('Guerry.shp')
-    gdf = gpd.read_file(link_to_data)
+    gdf = _test_data()
     x = gdf['Suicids'].values
     y = gdf['Donatns'].values
     w = Queen.from_dataframe(gdf)
@@ -48,9 +52,7 @@ def test_moran_scatterplot():
 
 def test_moran_global_scatterplot():
     # Load data and apply statistical analysis
-    guerry = examples.load_example('Guerry')
-    link_to_data = guerry.get_path('Guerry.shp')
-    gdf = gpd.read_file(link_to_data)
+    gdf = _test_data()
     y = gdf['Donatns'].values
     w = Queen.from_dataframe(gdf)
     w.transform = 'r'
@@ -69,9 +71,7 @@ def test_moran_global_scatterplot():
 
 def test_plot_moran_simulation():
     # Load data and apply statistical analysis
-    guerry = examples.load_example('Guerry')
-    link_to_data = guerry.get_path('Guerry.shp')
-    gdf = gpd.read_file(link_to_data)
+    gdf = _test_data()
     y = gdf['Donatns'].values
     w = Queen.from_dataframe(gdf)
     w.transform = 'r'
@@ -89,9 +89,7 @@ def test_plot_moran_simulation():
 
 def test_plot_moran():
     # Load data and apply statistical analysis
-    guerry = examples.load_example('Guerry')
-    link_to_data = guerry.get_path('Guerry.shp')
-    gdf = gpd.read_file(link_to_data)
+    gdf = _test_data()
     y = gdf['Donatns'].values
     w = Queen.from_dataframe(gdf)
     w.transform = 'r'
@@ -109,9 +107,7 @@ def test_plot_moran():
 
 
 def test_moran_bv_scatterplot():
-    guerry = examples.load_example('Guerry')
-    link_to_data = guerry.get_path('Guerry.shp')
-    gdf = gpd.read_file(link_to_data)
+    gdf = _test_data()
     x = gdf['Suicids'].values
     y = gdf['Donatns'].values
     w = Queen.from_dataframe(gdf)
@@ -129,9 +125,7 @@ def test_moran_bv_scatterplot():
 
 def test_plot_moran_bv_simulation():
     # Load data and calculate weights
-    guerry = examples.load_example('Guerry')
-    link_to_data = guerry.get_path('Guerry.shp')
-    gdf = gpd.read_file(link_to_data)
+    gdf = _test_data()
     x = gdf['Suicids'].values
     y = gdf['Donatns'].values
     w = Queen.from_dataframe(gdf)
@@ -149,9 +143,7 @@ def test_plot_moran_bv_simulation():
 
 def test_plot_moran_bv():
     # Load data and calculate weights
-    guerry = examples.load_example('Guerry')
-    link_to_data = guerry.get_path('Guerry.shp')
-    gdf = gpd.read_file(link_to_data)
+    gdf = _test_data()
     x = gdf['Suicids'].values
     y = gdf['Donatns'].values
     w = Queen.from_dataframe(gdf)
@@ -243,9 +235,7 @@ def test_plot_local_autocorrelation():
 
 
 def test_moran_loc_bv_scatterplot():
-    guerry = examples.load_example('Guerry')
-    link_to_data = guerry.get_path('Guerry.shp')
-    gdf = gpd.read_file(link_to_data)
+    gdf = _test_data()
     x = gdf['Suicids'].values
     y = gdf['Donatns'].values
     w = Queen.from_dataframe(gdf)


### PR DESCRIPTION
* update links to test datasets according to new libpysal api in `_test_viz_esda_mpl()`
* enforce to either pass `c` or `color` to `lines = ax.plot()` in `dynamic_lisa_vectors()`, not both if c is added by user as a kwargs argument. This adopts a deprecation warning: new error when both c and color are defined, implemented with matplotlib 3.3.

addresses #116 and  #117 