### PR TITLE
[BUG] enforce dtype in `mask` in `plot_local_autocorrelation()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
 
 
 script:
-  - python -c 'import libpysal; libpysal.examples.load_example("Guerry"); libpysal.examples.load_example("Rio Grande do Sul")'
+  - python -c 'import libpysal; libpysal.examples.load_example("Guerry"); libpysal.examples.load_example("Columbus"); libpysal.examples.load_example("Rio Grande do Sul")'
   - nosetests --verbose --with-doctest --with-coverage --cover-package=splot;
 #  - cd notebooks
 #  - make test

--- a/splot/_viz_esda_mpl.py
+++ b/splot/_viz_esda_mpl.py
@@ -1096,8 +1096,6 @@ def plot_local_autocorrelation(moran_loc, gdf, attribute, p=0.05,
                           " to dtype of first observation in region_column.")
             data_type = type(gdf[region_column][0].item())
             mask = list(map(data_type, mask))
-        else:
-            pass
 
         ix = gdf[region_column].isin(mask)
 

--- a/splot/_viz_esda_mpl.py
+++ b/splot/_viz_esda_mpl.py
@@ -958,8 +958,9 @@ def plot_local_autocorrelation(moran_loc, gdf, attribute, p=0.05,
         be colored by significance. Default = 0.05.
     region_column: string, optional
         Column name containing mask region of interest. Default = None
-    mask: str, optional
+    mask: str, float, int, optional
         Identifier or name of the region to highlight. Default = None
+        Use the same dtype to specifiy as in original dataset.
     mask_color: str, optional
         Color of mask. Default = '#636363'
     quadrant : int, optional

--- a/splot/_viz_esda_mpl.py
+++ b/splot/_viz_esda_mpl.py
@@ -36,7 +36,6 @@ def _create_moran_fig_ax(ax, figsize, aspect_equal):
         ax = fig.add_subplot(111)
     else:
         fig = ax.get_figure()
-    
     ax.spines['left'].set_position(('axes', -0.05))
     ax.spines['right'].set_color('none')
     ax.spines['bottom'].set_position(('axes', -0.05))
@@ -1089,7 +1088,21 @@ def plot_local_autocorrelation(moran_loc, gdf, attribute, p=0.05,
     # REGION MASKING
     if region_column is not None:
         # masking inside axs[0] or Moran Scatterplot
+        # enforce the same dtype of list and mask
+        if gdf[region_column].dtype != type(mask[0]):
+            warnings.warn("Values in `mask` are not the same dtype as" +
+                          " values in `region_column`. Converting `mask` values" +
+                          " to dtype of first observation in region_column.")
+            data_type = type(gdf[region_column][0].item())
+            mask = list(map(data_type, mask))
+        else:
+            pass
+
         ix = gdf[region_column].isin(mask)
+
+        if not ix.any():
+             raise ValueError('Specified values {} in `mask` not in `region_column`'.format(mask))
+
         df_mask = gdf[ix]
         x_mask = moran_loc.z[ix]
         y_mask = lag_spatial(moran_loc.w, moran_loc.z)[ix]

--- a/splot/tests/test_viz_esda_mpl.py
+++ b/splot/tests/test_viz_esda_mpl.py
@@ -232,7 +232,11 @@ def test_plot_local_autocorrelation():
                                         aspect_equal=False,
                                         mask=['1', '2', '3'], quadrant=1)
     plt.close(fig)
-
+    
+    # also test with quadrant and mask
+    assert_raises(ValueError, plot_local_autocorrelation, moran_loc,
+                  df, 'HOVAL', p=0.05, region_column='POLYID',
+                 mask=['100', '200', '300'], quadrant=1)
 
 def test_moran_loc_bv_scatterplot():
     gdf = _test_data()


### PR DESCRIPTION
splot build failing on `plot_local_autocorrelation()` for python v 3.7 due to change in behaviour in `pandas.DataFrame.isin()`.
For more information see #123.

* added functionality that converts values in `mask` to same type as values in `region_column`
* added warning that mask type and `region_column` type are not the same
* raising ValueError if specified values in `mask` not in the dataset
* add test to check ValueError is raised
* added comment in documentation
* Added Columbus dataset to travis.yml