### PR TITLE
DOC: update docs for bibtex>1

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,6 +46,7 @@ extensions = [  #'sphinx_gallery.gen_gallery',
     "matplotlib.sphinxext.plot_directive",
 ]
 
+bibtex_bibfiles = ["_static/references.bib"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
RTD build fails as we haven't updated `conf.py` to work with newer versions of `sphinxcontrib.bibtex`. This should fix it.