### PR TITLE
remove manual trigger

### DIFF
--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -5,13 +5,6 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
-  workflow_dispatch:
-    inputs:
-      version:
-        description: Manual Release
-        default: test
-        required: false
-  
 
 jobs:
   build:


### PR DESCRIPTION
This PR removes the manual trigger from `release_and_publish.yml`.